### PR TITLE
Disable debug mode on the mandrill library

### DIFF
--- a/WireMailMandrill.module
+++ b/WireMailMandrill.module
@@ -83,6 +83,7 @@ class WireMailMandrill extends WireMail implements Module, ConfigurableModule {
 		if ($this->apiKey) {
 			require_once($this->config->paths->WireMailMandrill . 'mandrill-api-php/src/Mandrill.php');
 			$this->mandrill = new Mandrill($this->apiKey);
+			$this->mandrill->debug = false;
 		}
 	}
 


### PR DESCRIPTION
...otherwise mandrill creates a test.log file in your /site/templates directory, which is very surprising.
